### PR TITLE
First somehow working clipboard implementation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,8 @@ sources = [
 	'src/main.c',
 	'src/app.c',
 	'src/config.c',
-	'src/save.c'
+	'src/save.c',
+	'src/clipboard.c'
 ]
 
 executable(

--- a/src/app.h
+++ b/src/app.h
@@ -8,17 +8,20 @@
 #include <X11/X.h>
 
 #include "config.h"
+#include "clipboard.h"
 
 typedef struct App {
 	int argc;
 	char **argv;
 	Config cfg;
+	Clipboard clipboard;
 	bool running;
 
 	Display *x_display;
 	Window x_window;
 	XWindowAttributes x_attribs;
 	XImage *image;
+	XEvent x_ev;
 
 	SDL_Window *window;
 	SDL_Event evt;
@@ -33,6 +36,7 @@ typedef struct App {
 
 void app_run(App *app, int argc, char** argv);
 void app_init(App *app);
+void app_handle_events(App *app);
 void app_update(App *app);
 void app_draw(App *app);
 void app_close(App *app);

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -1,0 +1,107 @@
+#include "clipboard.h"
+
+static void send_no(Display *dis, XSelectionRequestEvent *sev) {
+	XSelectionEvent ssev;
+
+	char *atom_name = XGetAtomName(dis, sev->target);
+	printf("Invalid atom: %s\n", XGetAtomName(dis, sev->target));
+	if (atom_name)
+		XFree(atom_name);
+
+	ssev.type = SelectionNotify;
+	ssev.requestor = sev->requestor;
+	ssev.selection = sev->selection;
+	ssev.target = sev->target;
+	ssev.property = None;
+	ssev.time = sev->time;
+
+	/* We need to tell requestor about wrong request */
+	XSendEvent(dis, sev->requestor, True, NoEventMask, (XEvent*)&ssev);
+}
+
+static void send_png(Display *dis, XSelectionRequestEvent *sev, Clipboard *clip) {
+	char *atom_name = XGetAtomName(dis, sev->target);
+	printf("%s\n", atom_name);
+	if (atom_name)
+		XFree(atom_name);
+
+	XSelectionEvent ssev;
+	XChangeProperty(dis, sev->requestor, sev->property, clip->png, 8, PropModeReplace, clip->data, clip->size);
+
+	ssev.type = SelectionNotify;
+	ssev.requestor = sev->requestor;
+	ssev.selection = sev->selection;
+	ssev.target = sev->target;
+	ssev.property = sev->property;
+	ssev.time = sev->time;
+
+	/* Answer requestor */
+	XSendEvent(dis, sev->requestor, True, NoEventMask, (XEvent*)&ssev);
+}
+
+/* Some applications need also TARGETS and we need to support it */
+static void send_targets(Display *dis, XSelectionRequestEvent *sev, Clipboard *clip) {
+	char *atom_name = XGetAtomName(dis, sev->target);
+	printf("%s\n", atom_name);
+	if (atom_name)
+		XFree(atom_name);
+
+	Atom atoms[] = {
+		clip->targets,
+		clip->sel,
+		clip->png,
+	};
+
+	XSelectionEvent ssev;
+	/* Save list of atoms */
+	XChangeProperty(dis, sev->requestor, sev->property, XA_ATOM, 32, PropModeReplace, &atoms, 3);
+
+	ssev.type = SelectionNotify;
+	ssev.requestor = sev->requestor;
+	ssev.selection = sev->selection;
+	ssev.target = sev->target;
+	ssev.property = sev->property;
+	ssev.time = sev->time;
+
+	XSendEvent(dis, sev->requestor, True, NoEventMask, (XEvent*)&ssev);
+}
+
+int clipboard_init(Clipboard *clip, Display *dis, Window root) {
+	if (clip == NULL) return -1;
+
+	/* Create window to receive messages */
+	clip->owner = XCreateSimpleWindow(dis, root, -10, -10, 1, 1, 0, 0, 0);
+
+	/* Listen for those */
+	clip->targets = XInternAtom(dis, "TARGETS", False);
+	clip->sel = XInternAtom(dis, "CLIPBOARD", False);
+	clip->png = XInternAtom(dis, "image/png", False);
+
+	/* Claim ownership */
+	XSetSelectionOwner(dis, clip->sel, clip->owner, CurrentTime);
+}
+
+void clipboard_manage(Clipboard *clip, Display *dis, XSelectionRequestEvent *sev) {
+	printf("Requestor: 0x%lx\n", sev->requestor);
+	
+	/* Ignore if property is None */
+	if (sev->property == None) {
+		send_no(dis, sev);
+		return;
+	}
+
+	if (sev->target == clip->png)
+		send_png(dis, sev, clip);
+	/* We need to accept TARGETS request, because if not, then programs dont know we have image in clipboard */
+	else if (sev->target == clip->targets)
+		send_targets(dis, sev, clip);
+	else if (sev->target == clip->plain)
+		send_png(dis, sev, clip);
+	else
+		send_no(dis, sev);
+}
+
+void clipboard_set_data(Clipboard *clip, unsigned char *data, size_t size) {
+	clip->data = data;
+	clip->size = size;
+}

--- a/src/clipboard.h
+++ b/src/clipboard.h
@@ -3,6 +3,8 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 
@@ -13,21 +15,40 @@ typedef struct Clipboard {
 	Window owner;
 	Atom targets;
 	Atom sel;
+	Atom save_targets;
+	Atom manager;
 	Atom png;
 	unsigned char *data;
 	size_t size;
+
+	Display *dis;
+	Window root;
 } Clipboard;
 
 /**
  * Inits a Clipboard fields to later use. 
- * @param clip Pointer to Clipboard, also see return
- * @param dis Pointer to Display, make sure it is correct
- * @return 0 on success, -1 if clip is NULL 
  */
-int clipboard_init(Clipboard *clip, Display *dis, Window root);
+void clipboard_init(Clipboard *clip, Display *dis, Window root);
 
+/**
+ * Sends request to clipboard manager to handle data. Use it if
+ * you don't have any plans with clipboard.
+ */
+void clipboard_close(Clipboard *clip);
+
+/**
+ * This should be used in event loop to handle X11 events.
+ */
 void clipboard_manage(Clipboard *clip, Display *dis, XSelectionRequestEvent *sev);
 
+/**
+ * Sets clipboard data to be sent to the requestor.
+ */
 void clipboard_set_data(Clipboard *clip, unsigned char *data, size_t size);
+
+/**
+ * Dirty way to handle screenshot. It is better to change this in the future.
+ */
+int clipboard_set_data_from_file(Clipboard *clip, const char *path);
 
 #endif

--- a/src/clipboard.h
+++ b/src/clipboard.h
@@ -1,0 +1,33 @@
+#ifndef CLIPBOARD_H
+#define CLIPBOARD_H
+
+#include <assert.h>
+#include <stdio.h>
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+
+/**
+ * Stuff required only by clipboard
+ */
+typedef struct Clipboard {
+	Window owner;
+	Atom targets;
+	Atom sel;
+	Atom png;
+	unsigned char *data;
+	size_t size;
+} Clipboard;
+
+/**
+ * Inits a Clipboard fields to later use. 
+ * @param clip Pointer to Clipboard, also see return
+ * @param dis Pointer to Display, make sure it is correct
+ * @return 0 on success, -1 if clip is NULL 
+ */
+int clipboard_init(Clipboard *clip, Display *dis, Window root);
+
+void clipboard_manage(Clipboard *clip, Display *dis, XSelectionRequestEvent *sev);
+
+void clipboard_set_data(Clipboard *clip, unsigned char *data, size_t size);
+
+#endif

--- a/src/clipboard.h
+++ b/src/clipboard.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
+#include <SDL2/SDL.h>
 
 /**
  * Stuff required only by clipboard
@@ -20,6 +21,7 @@ typedef struct Clipboard {
 	Atom png;
 	unsigned char *data;
 	size_t size;
+	bool done;
 
 	Display *dis;
 	Window root;
@@ -31,10 +33,18 @@ typedef struct Clipboard {
 void clipboard_init(Clipboard *clip, Display *dis, Window root);
 
 /**
- * Sends request to clipboard manager to handle data. Use it if
- * you don't have any plans with clipboard.
+ * Call this function only if data is provided through `clipboard_set_data_from_file`.
+ * Otherwise, it's not required.
+ * NOTE: it can cause double-free, so remove this function later
  */
 void clipboard_close(Clipboard *clip);
+
+/**
+ * Sends request to clipboard manager to handle data. Use it if
+ * you want to have data in clipboard manager. After using this function,
+ * wait for field `done` to be true.
+ */
+void clipboard_save(Clipboard *clip);
 
 /**
  * This should be used in event loop to handle X11 events.


### PR DESCRIPTION
I've been doing it for two days, but I'm even happy with the effect.

The result came out a little strange because of the design of the program and will have to be reworked. 

It's quite simple API to manage clipboard, by the way I added event handling to the program to know when clipboard should respond. I could optionally just add it to the clipboard as a separate thread, but it should be okay.

By the way it changes the behavior of the program a little bit, because now it doesn't just turn off, but waits 2 more seconds until the clipboard manager is able to copy the data.

Quirks:
- Requires a clipboard manager. This is fully correct behavior according to freedesktop specifications, but sometimes it can be annoying for users.
- `clipboard_set_data_from_file`. This should not occur in the final version.
- `clipboard_clean` can cause double-free if used wrong way.
- The design of a program doesn't really match the way such a program should work, so it would be better to change it.
- The logging remains have been and it would be good to turn them on with some option, because the clipboard in X11 is veeeeeery complicated and logs would be useful.